### PR TITLE
fix: 添加全局输入框占位符样式规则，修复主题切换样式不一致的问题

### DIFF
--- a/packages/ai-chat-pc/src/App.tsx
+++ b/packages/ai-chat-pc/src/App.tsx
@@ -36,7 +36,6 @@ function App() {
     <ConfigProvider locale={antdLocale} theme={themeConfig}>
       <XProvider theme={themeConfig}>
         <div className="min-h-screen">
-          <LanguageSwitch />
           <Outlet />
           <ThemeToggle />
         </div>

--- a/packages/ai-chat-pc/src/index.css
+++ b/packages/ai-chat-pc/src/index.css
@@ -11,5 +11,14 @@
     }
 
     
+        
+    /* 添加 placeholder 样式 */
+    input::placeholder {
+        @apply text-gray-500;
+    }
+    
+    .dark input::placeholder {
+        @apply text-gray-300;
+    }
 
 }


### PR DESCRIPTION
1.  移除整体语言控制按钮，待后续调整
2.  添加全局输入框占位符样式规则，修复主题切换时占位符样式不一致的问题